### PR TITLE
Use isWindowVisible setting instead of forcing window visible

### DIFF
--- a/WhereToPlay/FCT.lua
+++ b/WhereToPlay/FCT.lua
@@ -16,7 +16,7 @@ function UpdateLvl()
 		settings["playerLvl"]["value"] = curentLvl;
 		WhereToPlay:SetVisible(false);
 		CreateMainWindow();
-		WhereToPlay:SetVisible(true);
+		WhereToPlay:SetVisible(settings["isWindowVisible"]["isWindowVisible"]);
 	end
 end
 ------------------------------------------------------------------------------------------


### PR DESCRIPTION
Prevents the WhereToPlay window appearing at every character level up.

Fix as discussed on [lotrointerface.com](https://www.lotrointerface.com/downloads/info1138-WhereToPlay.html)